### PR TITLE
Bulk actions, patcher rewrite, Discord fixes, UI improvements

### DIFF
--- a/protos/profiles.proto
+++ b/protos/profiles.proto
@@ -12,23 +12,23 @@ service ProfileService {
   // CRUD operations - mutations return Empty, data arrives via events
   rpc Create(Profile) returns (google.protobuf.Empty);
   rpc Update(UpdateProfileRequest) returns (google.protobuf.Empty);
-  rpc Delete(ProfileName) returns (google.protobuf.Empty);
+  rpc Delete(ProfileNames) returns (google.protobuf.Empty);
 
   // Profile actions (accepts list of profile names)
   rpc Start(ProfileNames) returns (google.protobuf.Empty);
   rpc Stop(ProfileNames) returns (google.protobuf.Empty);
-  rpc Restart(RestartRequest) returns (google.protobuf.Empty);
 
   // Window control (accepts list of profile names)
   rpc ShowWindow(ProfileNames) returns (google.protobuf.Empty);
   rpc HideWindow(ProfileNames) returns (google.protobuf.Empty);
 
-  // Stats and keys
-  rpc ResetStats(ProfileName) returns (google.protobuf.Empty);
-  rpc TriggerMule(ProfileName) returns (google.protobuf.Empty);
-  rpc RotateKey(ProfileName) returns (google.protobuf.Empty);
-  rpc ReleaseKey(ProfileName) returns (google.protobuf.Empty);
-  rpc SetScheduleEnabled(SetScheduleEnabledRequest) returns (google.protobuf.Empty);
+  // Stats and keys (accepts list of profile names)
+  rpc ResetStats(ProfileNames) returns (google.protobuf.Empty);
+  rpc TriggerMule(ProfileNames) returns (google.protobuf.Empty);
+  rpc RotateKey(ProfileNames) returns (google.protobuf.Empty);
+  rpc ReleaseKey(ProfileNames) returns (google.protobuf.Empty);
+  rpc EnableSchedule(ProfileNames) returns (google.protobuf.Empty);
+  rpc DisableSchedule(ProfileNames) returns (google.protobuf.Empty);
 
   // Reordering
   rpc Reorder(ReorderProfileRequest) returns (google.protobuf.Empty);
@@ -96,16 +96,6 @@ message ProfileState {
   // profile fields changed (e.g. stats, key rotation, settings). When absent in
   // events, clients should retain their cached profile data keyed by profile_name.
   optional Profile profile = 40;
-}
-
-message RestartRequest {
-  string profile_name = 1;
-  bool rotate_key = 2;
-}
-
-message SetScheduleEnabledRequest {
-  string profile_name = 1;
-  bool enabled = 2;
 }
 
 message ReorderProfileRequest {

--- a/src/D2BotNG.UI/src/features/items/ItemCard.tsx
+++ b/src/D2BotNG.UI/src/features/items/ItemCard.tsx
@@ -28,7 +28,7 @@ export const ItemCard = memo(function ItemCard({
   return (
     <div
       className={clsx(
-        "flex items-center gap-3 rounded-lg bg-zinc-900 p-3 ring-1 ring-zinc-800 transition-colors hover:ring-zinc-700",
+        "flex min-w-0 items-center gap-3 rounded-lg bg-zinc-900 p-3 ring-1 ring-zinc-800 transition-colors hover:ring-zinc-700",
         className,
       )}
       onMouseEnter={() => setIsHovered(true)}
@@ -54,17 +54,32 @@ export const ItemCard = memo(function ItemCard({
         )}
       </div>
 
-      {/* Socket count indicator */}
-      {item.sockets.length > 0 && (
-        <div
-          className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-zinc-700 text-xs font-bold text-zinc-100"
-          title={
-            item.sockets.length +
-            " socket" +
-            (item.sockets.length > 1 ? "s" : "")
-          }
-        >
-          {item.sockets.length}
+      {/* Item badges */}
+      {(item.sockets.length > 0 || item.description?.includes("Ethereal")) && (
+        <div className="flex flex-shrink-0 flex-col items-center gap-1">
+          {/* Socket count indicator */}
+          {item.sockets.length > 0 && (
+            <div
+              className="flex h-6 w-6 items-center justify-center rounded-full bg-zinc-700 text-xs font-bold text-zinc-100"
+              title={
+                item.sockets.length +
+                " socket" +
+                (item.sockets.length > 1 ? "s" : "")
+              }
+            >
+              {item.sockets.length}
+            </div>
+          )}
+
+          {/* Ethereal indicator */}
+          {item.description?.includes("Ethereal") && (
+            <div
+              className="flex h-6 w-6 items-center justify-center rounded-full bg-cyan-900/60 text-xs font-bold text-cyan-300"
+              title="Ethereal"
+            >
+              E
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/D2BotNG.UI/src/features/profiles/ProfileActions.tsx
+++ b/src/D2BotNG.UI/src/features/profiles/ProfileActions.tsx
@@ -2,6 +2,7 @@
  * ProfileActions component
  *
  * Dropdown menu with profile actions like start/stop, show/hide window, etc.
+ * Also exports pure builder functions for use in context menus.
  */
 
 import { useNavigate } from "react-router-dom";
@@ -9,6 +10,7 @@ import { Dropdown, type DropdownItem } from "@/components/ui";
 import { useProfileActions, useIsLocalhost } from "@/hooks";
 import { RunState } from "@/generated/common_pb";
 import type { Profile, ProfileState } from "@/generated/profiles_pb";
+import { canStart, canStop, isActive } from "./profile-states";
 import {
   PlayIcon,
   StopIcon,
@@ -32,6 +34,277 @@ export interface ProfileActionsProps {
   onDelete: (profile: Profile) => void;
 }
 
+export interface BuildSingleParams {
+  profile: Profile;
+  status?: ProfileState;
+  isLocalhost: boolean;
+  actions: ReturnType<typeof useProfileActions>;
+  onEdit: (profile: Profile) => void;
+  onClone: (profile: Profile) => void;
+  onDelete: (profile: Profile) => void;
+}
+
+export interface BuildMultiParams {
+  profiles: Profile[];
+  statuses: Record<string, ProfileState | undefined>;
+  isLocalhost: boolean;
+  actions: ReturnType<typeof useProfileActions>;
+  onDelete: (names: string[]) => void;
+}
+
+/** Pure builder for single-profile context menu items */
+export function buildSingleProfileActionItems({
+  profile,
+  status,
+  isLocalhost,
+  actions,
+  onEdit,
+  onClone,
+  onDelete,
+}: BuildSingleParams): DropdownItem[] {
+  const state = status?.state;
+  const windowVisible = status?.windowVisible ?? false;
+  const scheduleEnabled = profile.scheduleEnabled;
+
+  const isStopped = state === RunState.STOPPED || state === undefined;
+
+  return [
+    {
+      label: "Edit",
+      icon: PencilSquareIcon,
+      onClick: () => onEdit(profile),
+    },
+    // Show Start/Stop based on state machine — Error state gets both
+    ...(canStart(state)
+      ? [
+          {
+            label: "Start",
+            icon: PlayIcon,
+            onClick: () => actions.start.mutate([profile.name]),
+          },
+        ]
+      : []),
+    ...(canStop(state)
+      ? [
+          {
+            label: "Stop",
+            icon: StopIcon,
+            onClick: () => actions.stop.mutate([profile.name]),
+          },
+        ]
+      : []),
+    // Show/Hide Window — only when profile is active (has a game process)
+    ...(isLocalhost && isActive(state)
+      ? [
+          windowVisible
+            ? {
+                label: "Hide Window",
+                icon: EyeSlashIcon,
+                onClick: () => actions.hideWindow.mutate([profile.name]),
+              }
+            : {
+                label: "Show Window",
+                icon: EyeIcon,
+                onClick: () => actions.showWindow.mutate([profile.name]),
+              },
+        ]
+      : []),
+    {
+      label: "Clone",
+      icon: DocumentDuplicateIcon,
+      onClick: () => onClone(profile),
+    },
+    {
+      label: "Reset Stats",
+      icon: ArrowPathIcon,
+      onClick: () => actions.resetStats.mutate([profile.name]),
+    },
+    // Trigger Mule — only when running
+    ...(state === RunState.RUNNING
+      ? [
+          {
+            label: "Trigger Mule",
+            icon: CubeIcon,
+            onClick: () => actions.triggerMule.mutate([profile.name]),
+          },
+        ]
+      : []),
+    // Rotate Key — only when holding a key (swaps to next available)
+    ...(status?.keyName
+      ? [
+          {
+            label: "Rotate Key",
+            icon: KeyIcon,
+            onClick: () => actions.rotateKey.mutate([profile.name]),
+          },
+        ]
+      : []),
+    // Release Key — only when holding a key
+    ...(status?.keyName
+      ? [
+          {
+            label: "Release Key",
+            icon: LockOpenIcon,
+            onClick: () => actions.releaseKey.mutate([profile.name]),
+          },
+        ]
+      : []),
+    scheduleEnabled
+      ? {
+          label: "Disable Schedule",
+          icon: CalendarIcon,
+          onClick: () => actions.disableSchedule.mutate([profile.name]),
+        }
+      : {
+          label: "Enable Schedule",
+          icon: CalendarDaysIcon,
+          onClick: () => actions.enableSchedule.mutate([profile.name]),
+        },
+    // Delete — only when stopped
+    ...(isStopped
+      ? [
+          {
+            label: "Delete",
+            icon: TrashIcon,
+            onClick: () => onDelete(profile),
+            danger: true,
+          },
+        ]
+      : []),
+  ];
+}
+
+/** Pure builder for multi-profile context menu items */
+export function buildMultiProfileActionItems({
+  profiles,
+  statuses,
+  isLocalhost,
+  actions,
+  onDelete,
+}: BuildMultiParams): DropdownItem[] {
+  const names = profiles.map((p) => p.name);
+  const count = names.length;
+
+  const startableNames: string[] = [];
+  const stoppableNames: string[] = [];
+  const showableNames: string[] = []; // active + window hidden
+  const hidableNames: string[] = []; // active + window visible
+  const stoppedNames: string[] = []; // for delete
+  const keyHolderNames: string[] = []; // for release key
+  const hasScheduleEnabled = profiles.some((p) => p.scheduleEnabled);
+  const hasScheduleDisabled = profiles.some((p) => !p.scheduleEnabled);
+
+  for (const profile of profiles) {
+    const status = statuses[profile.name];
+    const state = status?.state;
+    if (canStart(state)) startableNames.push(profile.name);
+    if (canStop(state)) stoppableNames.push(profile.name);
+    if (isActive(state)) {
+      if (status?.windowVisible) hidableNames.push(profile.name);
+      else showableNames.push(profile.name);
+    }
+    if (state === RunState.STOPPED || state === undefined)
+      stoppedNames.push(profile.name);
+    if (status?.keyName) keyHolderNames.push(profile.name);
+  }
+
+  return [
+    ...(startableNames.length > 0
+      ? [
+          {
+            label: `Start (${startableNames.length})`,
+            icon: PlayIcon,
+            onClick: () => actions.start.mutate(startableNames),
+          },
+        ]
+      : []),
+    ...(stoppableNames.length > 0
+      ? [
+          {
+            label: `Stop (${stoppableNames.length})`,
+            icon: StopIcon,
+            onClick: () => actions.stop.mutate(stoppableNames),
+          },
+        ]
+      : []),
+    ...(isLocalhost && showableNames.length > 0
+      ? [
+          {
+            label: `Show Window (${showableNames.length})`,
+            icon: EyeIcon,
+            onClick: () => actions.showWindow.mutate(showableNames),
+          },
+        ]
+      : []),
+    ...(isLocalhost && hidableNames.length > 0
+      ? [
+          {
+            label: `Hide Window (${hidableNames.length})`,
+            icon: EyeSlashIcon,
+            onClick: () => actions.hideWindow.mutate(hidableNames),
+          },
+        ]
+      : []),
+    {
+      label: `Reset Stats (${count})`,
+      icon: ArrowPathIcon,
+      onClick: () => actions.resetStats.mutate(names),
+    },
+    ...(keyHolderNames.length > 0
+      ? [
+          {
+            label: `Rotate Key (${keyHolderNames.length})`,
+            icon: KeyIcon,
+            onClick: () => actions.rotateKey.mutate(keyHolderNames),
+          },
+        ]
+      : []),
+    ...(keyHolderNames.length > 0
+      ? [
+          {
+            label: `Release Key (${keyHolderNames.length})`,
+            icon: LockOpenIcon,
+            onClick: () => actions.releaseKey.mutate(keyHolderNames),
+          },
+        ]
+      : []),
+    ...(hasScheduleDisabled
+      ? [
+          {
+            label: `Enable Schedule (${profiles.filter((p) => !p.scheduleEnabled).length})`,
+            icon: CalendarDaysIcon,
+            onClick: () =>
+              actions.enableSchedule.mutate(
+                profiles.filter((p) => !p.scheduleEnabled).map((p) => p.name),
+              ),
+          },
+        ]
+      : []),
+    ...(hasScheduleEnabled
+      ? [
+          {
+            label: `Disable Schedule (${profiles.filter((p) => p.scheduleEnabled).length})`,
+            icon: CalendarIcon,
+            onClick: () =>
+              actions.disableSchedule.mutate(
+                profiles.filter((p) => p.scheduleEnabled).map((p) => p.name),
+              ),
+          },
+        ]
+      : []),
+    ...(stoppedNames.length > 0
+      ? [
+          {
+            label: `Delete (${stoppedNames.length})`,
+            icon: TrashIcon,
+            onClick: () => onDelete(stoppedNames),
+            danger: true,
+          },
+        ]
+      : []),
+  ];
+}
+
 export function useProfileActionItems({
   profile,
   status,
@@ -42,111 +315,15 @@ export function useProfileActionItems({
   const actions = useProfileActions();
   const isLocalhost = useIsLocalhost();
 
-  const isRunning =
-    status?.state === RunState.STARTING || status?.state === RunState.RUNNING;
-  const isStopped = !status || status.state === RunState.STOPPED;
-  const windowVisible = status?.windowVisible ?? false;
-  const scheduleEnabled = profile.scheduleEnabled;
-
-  return [
-    // Edit profile
-    {
-      label: "Edit",
-      icon: PencilSquareIcon,
-      onClick: () => navigate(`/profiles/${encodeURIComponent(profile.name)}`),
-    },
-    // Start/Stop toggle
-    isStopped
-      ? {
-          label: "Start",
-          icon: PlayIcon,
-          onClick: () => actions.start.mutate([profile.name]),
-        }
-      : {
-          label: "Stop",
-          icon: StopIcon,
-          onClick: () => actions.stop.mutate([profile.name]),
-        },
-    // Show/Hide Window toggle (only on localhost, only enabled when running)
-    ...(isLocalhost
-      ? [
-          windowVisible
-            ? {
-                label: "Hide Window",
-                icon: EyeSlashIcon,
-                onClick: () => actions.hideWindow.mutate([profile.name]),
-                disabled: isStopped,
-              }
-            : {
-                label: "Show Window",
-                icon: EyeIcon,
-                onClick: () => actions.showWindow.mutate([profile.name]),
-                disabled: isStopped,
-              },
-        ]
-      : []),
-    // Clone
-    {
-      label: "Clone",
-      icon: DocumentDuplicateIcon,
-      onClick: () => onClone(profile),
-    },
-    // Reset Stats
-    {
-      label: "Reset Stats",
-      icon: ArrowPathIcon,
-      onClick: () => actions.resetStats.mutate(profile.name),
-    },
-    // Trigger Mule (disabled if not running)
-    {
-      label: "Trigger Mule",
-      icon: CubeIcon,
-      onClick: () => actions.triggerMule.mutate(profile.name),
-      disabled: !isRunning,
-    },
-    // Rotate Key (only when stopped)
-    {
-      label: "Rotate Key",
-      icon: KeyIcon,
-      onClick: () => actions.rotateKey.mutate(profile.name),
-      disabled: !isStopped,
-    },
-    // Release Key (only when a key is assigned)
-    {
-      label: "Release Key",
-      icon: LockOpenIcon,
-      onClick: () => actions.releaseKey.mutate(profile.name),
-      disabled: !status?.keyName,
-    },
-    // Enable/Disable Schedule toggle
-    scheduleEnabled
-      ? {
-          label: "Disable Schedule",
-          icon: CalendarIcon,
-          onClick: () =>
-            actions.setScheduleEnabled.mutate({
-              profileName: profile.name,
-              enabled: false,
-            }),
-        }
-      : {
-          label: "Enable Schedule",
-          icon: CalendarDaysIcon,
-          onClick: () =>
-            actions.setScheduleEnabled.mutate({
-              profileName: profile.name,
-              enabled: true,
-            }),
-        },
-    // Delete (danger, disabled when not fully stopped)
-    {
-      label: "Delete",
-      icon: TrashIcon,
-      onClick: () => onDelete(profile),
-      danger: true,
-      disabled: !isStopped,
-    },
-  ];
+  return buildSingleProfileActionItems({
+    profile,
+    status,
+    isLocalhost,
+    actions,
+    onEdit: (p) => navigate(`/profiles/${encodeURIComponent(p.name)}`),
+    onClone,
+    onDelete,
+  });
 }
 
 export function ProfileActions(props: ProfileActionsProps) {

--- a/src/D2BotNG.UI/src/features/profiles/profile-states.ts
+++ b/src/D2BotNG.UI/src/features/profiles/profile-states.ts
@@ -1,0 +1,30 @@
+/**
+ * UI-side mirror of the backend state machine (ProfileInstance.IsValidTransition).
+ *
+ * Valid transitions:
+ *   Stopped  → Starting
+ *   Starting → Running | Error
+ *   Running  → Stopping | Error
+ *   Stopping → Stopped
+ *   Error    → Starting | Stopping | Stopped
+ */
+
+import { RunState } from "@/generated/common_pb";
+
+/** Profile can be started (state allows transition to Starting). */
+export function canStart(state: RunState | undefined): boolean {
+  if (state === undefined) return true; // No status = treat as stopped
+  return state === RunState.STOPPED || state === RunState.ERROR;
+}
+
+/** Profile can be stopped (state allows transition to Stopping). */
+export function canStop(state: RunState | undefined): boolean {
+  if (state === undefined) return false;
+  return state === RunState.RUNNING || state === RunState.ERROR;
+}
+
+/** Profile is actively running with a game process (has a window). */
+export function isActive(state: RunState | undefined): boolean {
+  if (state === undefined) return false;
+  return state === RunState.STARTING || state === RunState.RUNNING;
+}

--- a/src/D2BotNG.UI/src/hooks/index.ts
+++ b/src/D2BotNG.UI/src/hooks/index.ts
@@ -66,3 +66,6 @@ export type { ProfileColumnKey, ProfileColumn } from "./useProfileTableColumns";
 
 // Localhost check hook
 export { useIsLocalhost } from "./useIsLocalhost";
+
+// Hover capability hook
+export { useHasHover } from "./useHasHover";

--- a/src/D2BotNG.UI/src/hooks/useDeleteDialog.ts
+++ b/src/D2BotNG.UI/src/hooks/useDeleteDialog.ts
@@ -45,8 +45,9 @@ interface UseDeleteDialogResult<T extends Entity> {
  *   isPending={deleteProfile.isPending}
  * />
  */
-export function useDeleteDialog<T extends Entity>(
-  deleteMutation: UseMutationResult<void, Error, string>,
+export function useDeleteDialog<T extends Entity, TArg = string>(
+  deleteMutation: UseMutationResult<void, Error, TArg>,
+  mapName?: (name: string) => TArg,
 ): UseDeleteDialogResult<T> {
   const [deleteTarget, setDeleteTarget] = useState<T | null>(null);
 
@@ -56,10 +57,13 @@ export function useDeleteDialog<T extends Entity>(
 
   const confirmDelete = useCallback(() => {
     if (deleteTarget) {
-      deleteMutation.mutate(deleteTarget.name);
+      const arg = mapName
+        ? mapName(deleteTarget.name)
+        : (deleteTarget.name as TArg);
+      deleteMutation.mutate(arg);
       setDeleteTarget(null);
     }
-  }, [deleteTarget, deleteMutation]);
+  }, [deleteTarget, deleteMutation, mapName]);
 
   const cancelDelete = useCallback(() => {
     setDeleteTarget(null);

--- a/src/D2BotNG.UI/src/hooks/useHasHover.ts
+++ b/src/D2BotNG.UI/src/hooks/useHasHover.ts
@@ -1,0 +1,20 @@
+import { useSyncExternalStore } from "react";
+
+const query = window.matchMedia("(hover: hover)");
+
+function subscribe(callback: () => void) {
+  query.addEventListener("change", callback);
+  return () => query.removeEventListener("change", callback);
+}
+
+function getSnapshot() {
+  return query.matches;
+}
+
+/**
+ * Hook to check if the device has hover capability (desktop/mouse).
+ * Reactively updates when hover capability changes (e.g. mouse connected/disconnected).
+ */
+export function useHasHover(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/src/D2BotNG.UI/src/hooks/useProfiles.ts
+++ b/src/D2BotNG.UI/src/hooks/useProfiles.ts
@@ -13,7 +13,7 @@ import {
   ReorderProfileRequestSchema,
   UpdateProfileRequestSchema,
 } from "@/generated/profiles_pb";
-import { ProfileNameSchema, ProfileNamesSchema } from "@/generated/common_pb";
+import { ProfileNamesSchema } from "@/generated/common_pb";
 
 export type ProfileInput = MessageInitShape<typeof ProfileSchema>;
 export type UpdateProfileInput = MessageInitShape<
@@ -66,13 +66,9 @@ export function useUpdateProfile() {
  */
 export function useDeleteProfile() {
   return useMutation({
-    mutationFn: async (name: string) => {
-      const request = create(ProfileNameSchema, { name });
+    mutationFn: async (names: string[]) => {
+      const request = create(ProfileNamesSchema, { names });
       await profileClient.delete(request);
-    },
-    onSuccess: () => {
-      // Data arrives via event stream - no need to invalidate queries
-      toast.success("Profile deleted");
     },
     onError: (error) => {
       toast.error("Failed to delete profile", error.message);
@@ -90,13 +86,6 @@ export function useProfileActions() {
       const request = create(ProfileNamesSchema, { names });
       await profileClient.start(request);
     },
-    onSuccess: (_, names) => {
-      toast.success(
-        names.length === 1
-          ? "Profile started"
-          : `${names.length} profiles started`,
-      );
-    },
     onError: (error) => {
       toast.error("Failed to start profile", error.message);
     },
@@ -106,13 +95,6 @@ export function useProfileActions() {
     mutationFn: async (names: string[]) => {
       const request = create(ProfileNamesSchema, { names });
       await profileClient.stop(request);
-    },
-    onSuccess: (_, names) => {
-      toast.success(
-        names.length === 1
-          ? "Profile stopped"
-          : `${names.length} profiles stopped`,
-      );
     },
     onError: (error) => {
       toast.error("Failed to stop profile", error.message);
@@ -124,11 +106,6 @@ export function useProfileActions() {
       const request = create(ProfileNamesSchema, { names });
       await profileClient.showWindow(request);
     },
-    onSuccess: (_, names) => {
-      toast.success(
-        names.length === 1 ? "Window shown" : `${names.length} windows shown`,
-      );
-    },
     onError: (error) => {
       toast.error("Failed to show window", error.message);
     },
@@ -139,23 +116,15 @@ export function useProfileActions() {
       const request = create(ProfileNamesSchema, { names });
       await profileClient.hideWindow(request);
     },
-    onSuccess: (_, names) => {
-      toast.success(
-        names.length === 1 ? "Window hidden" : `${names.length} windows hidden`,
-      );
-    },
     onError: (error) => {
       toast.error("Failed to hide window", error.message);
     },
   });
 
   const resetStats = useMutation({
-    mutationFn: async (name: string) => {
-      const request = create(ProfileNameSchema, { name });
+    mutationFn: async (names: string[]) => {
+      const request = create(ProfileNamesSchema, { names });
       await profileClient.resetStats(request);
-    },
-    onSuccess: () => {
-      toast.success("Stats reset");
     },
     onError: (error) => {
       toast.error("Failed to reset stats", error.message);
@@ -163,12 +132,9 @@ export function useProfileActions() {
   });
 
   const triggerMule = useMutation({
-    mutationFn: async (name: string) => {
-      const request = create(ProfileNameSchema, { name });
+    mutationFn: async (names: string[]) => {
+      const request = create(ProfileNamesSchema, { names });
       await profileClient.triggerMule(request);
-    },
-    onSuccess: () => {
-      toast.success("Mule triggered");
     },
     onError: (error) => {
       toast.error("Failed to trigger mule", error.message);
@@ -176,12 +142,9 @@ export function useProfileActions() {
   });
 
   const rotateKey = useMutation({
-    mutationFn: async (name: string) => {
-      const request = create(ProfileNameSchema, { name });
+    mutationFn: async (names: string[]) => {
+      const request = create(ProfileNamesSchema, { names });
       await profileClient.rotateKey(request);
-    },
-    onSuccess: () => {
-      toast.success("Key rotated");
     },
     onError: (error) => {
       toast.error("Failed to rotate key", error.message);
@@ -189,33 +152,32 @@ export function useProfileActions() {
   });
 
   const releaseKey = useMutation({
-    mutationFn: async (name: string) => {
-      const request = create(ProfileNameSchema, { name });
+    mutationFn: async (names: string[]) => {
+      const request = create(ProfileNamesSchema, { names });
       await profileClient.releaseKey(request);
-    },
-    onSuccess: () => {
-      toast.success("Key released");
     },
     onError: (error) => {
       toast.error("Failed to release key", error.message);
     },
   });
 
-  const setScheduleEnabled = useMutation({
-    mutationFn: async ({
-      profileName,
-      enabled,
-    }: {
-      profileName: string;
-      enabled: boolean;
-    }) => {
-      await profileClient.setScheduleEnabled({ profileName, enabled });
-    },
-    onSuccess: (_, { enabled }) => {
-      toast.success(enabled ? "Schedule enabled" : "Schedule disabled");
+  const enableSchedule = useMutation({
+    mutationFn: async (names: string[]) => {
+      const request = create(ProfileNamesSchema, { names });
+      await profileClient.enableSchedule(request);
     },
     onError: (error) => {
-      toast.error("Failed to update schedule", error.message);
+      toast.error("Failed to enable schedule", error.message);
+    },
+  });
+
+  const disableSchedule = useMutation({
+    mutationFn: async (names: string[]) => {
+      const request = create(ProfileNamesSchema, { names });
+      await profileClient.disableSchedule(request);
+    },
+    onError: (error) => {
+      toast.error("Failed to disable schedule", error.message);
     },
   });
 
@@ -250,7 +212,8 @@ export function useProfileActions() {
     triggerMule,
     rotateKey,
     releaseKey,
-    setScheduleEnabled,
+    enableSchedule,
+    disableSchedule,
     reorder,
   };
 }

--- a/src/D2BotNG/Data/PatchRepository.cs
+++ b/src/D2BotNG/Data/PatchRepository.cs
@@ -24,9 +24,9 @@ public class PatchRepository : FileRepository<Patch, PatchList>
         return list;
     }
 
-    public IEnumerable<Patch> GetPatchesForVersion(string version)
+    public async Task<IEnumerable<Patch>> GetPatchesForVersionAsync(string version)
     {
-        return Data.Where(p => p.Version == version);
+        return (await GetAllAsync()).Where(p => p.Version == version);
     }
 
     public static string GetModuleName(D2Module module)

--- a/src/D2BotNG/Data/ProfileRepository.cs
+++ b/src/D2BotNG/Data/ProfileRepository.cs
@@ -26,6 +26,6 @@ public class ProfileRepository : FileRepository<Profile, ProfileList>
     protected override async Task SaveAsync()
     {
         await base.SaveAsync();
-        await _iniWriter.WriteAsync(Data);
+        await _iniWriter.WriteAsync(await GetAllAsync());
     }
 }

--- a/src/D2BotNG/Engine/ProfileInstance.cs
+++ b/src/D2BotNG/Engine/ProfileInstance.cs
@@ -70,6 +70,7 @@ public class ProfileInstance : IDisposable
         {
             State = RunState.Error;
             Status = error;
+            KeyName = null;
         }
         finally
         {

--- a/src/D2BotNG/Services/D2BSMessageHandler.cs
+++ b/src/D2BotNG/Services/D2BSMessageHandler.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using D2BotNG.Core.Protos;
+using D2BotNG.Data.LegacyModels;
 using D2BotNG.Data;
 using D2BotNG.Engine;
 using D2BotNG.Utilities;
@@ -95,6 +96,11 @@ public class D2BSMessageHandler : BackgroundService
             case "printToConsole":
                 if (args.Length > 0)
                     HandlePrintToConsole(profile.Name, args);
+                break;
+
+            case "printToItemLog":
+                if (args.Length > 0 && args[0].Length > 0)
+                    HandlePrintToItemLog(profile.Name, args[0]);
                 break;
 
             case "getProfile":
@@ -250,6 +256,12 @@ public class D2BSMessageHandler : BackgroundService
     {
         profile.Deaths++;
         await _profileEngine.UpdateProfileAndNotifyAsync(profile);
+    }
+
+    private void HandlePrintToItemLog(string profileName, string itemJson)
+    {
+        var legacyItem = JsonSerializer.Deserialize<LegacyItem>(itemJson)!;
+        _messageService.AddMessage(profileName, legacyItem.Title, MessageColor.ColorDefault, legacyItem.ToModern());
     }
 
     private void HandlePrintToConsole(string profileName, string[] args)

--- a/src/D2BotNG/Services/IniWriter.cs
+++ b/src/D2BotNG/Services/IniWriter.cs
@@ -24,7 +24,7 @@ public class IniWriter
     /// <summary>
     /// Write all profiles to d2bs.ini.
     /// </summary>
-    public async Task WriteAsync(List<Profile> profiles)
+    public async Task WriteAsync(IReadOnlyList<Profile> profiles)
     {
         var iniPath = Path.Combine(_paths.D2BSDirectory, "d2bs.ini");
         if (!File.Exists(iniPath))

--- a/src/D2BotNG/Services/UpdateManager.cs
+++ b/src/D2BotNG/Services/UpdateManager.cs
@@ -84,6 +84,12 @@ public class UpdateManager
 
     public async Task CheckForUpdateAsync(CancellationToken cancellationToken = default)
     {
+        if (_currentVersion == "0.0.0")
+        {
+            _logger.LogDebug("Skipping update check for non-release build (version 0.0.0)");
+            return;
+        }
+
         UpdateStatusAndBroadcast(s =>
         {
             s.State = UpdateState.Checking;

--- a/src/D2BotNG/Windows/NativeMethods.cs
+++ b/src/D2BotNG/Windows/NativeMethods.cs
@@ -55,6 +55,9 @@ public static class NativeMethods
     [DllImport("kernel32.dll", SetLastError = true)]
     public static extern uint WaitForSingleObject(nint hHandle, uint dwMilliseconds);
 
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool GetExitCodeThread(nint hThread, out uint lpExitCode);
+
     #endregion
 
     #region kernel32.dll - Process Creation
@@ -142,6 +145,7 @@ public static class NativeMethods
 
     [DllImport("user32.dll")]
     public static extern bool IsWindowVisible(nint hWnd);
+
 
     #endregion
 

--- a/src/D2BotNG/Windows/NativeTypes.cs
+++ b/src/D2BotNG/Windows/NativeTypes.cs
@@ -96,6 +96,8 @@ public static class NativeTypes
     public const uint PROCESS_VM_OPERATION = 0x0008;
     public const uint PROCESS_VM_READ = 0x0010;
     public const uint PROCESS_VM_WRITE = 0x0020;
+    public const uint PROCESS_CREATE_THREAD = 0x0002;
+    public const uint PROCESS_QUERY_INFORMATION = 0x0400;
     public const uint WRITE_DAC = 0x00040000;
 
     // Thread access rights (DWORD)
@@ -141,6 +143,9 @@ public static class NativeTypes
 
     // Special window handles
     public static readonly nint HWND_MESSAGE = -3;
+
+    // Wait constants
+    public const uint INFINITE = 0xFFFFFFFF;
 
     #endregion
 }

--- a/src/D2BotNG/Windows/Patcher.cs
+++ b/src/D2BotNG/Windows/Patcher.cs
@@ -17,7 +17,23 @@ public class Patcher
     {
         try
         {
-            var moduleBase = GetModuleBaseAddress(process, module);
+            var rawHandle = OpenProcess(
+                PROCESS_CREATE_THREAD | PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_QUERY_INFORMATION,
+                false, process.Id);
+            if (rawHandle == 0)
+            {
+                _logger.LogError("Failed to open process {Pid} for patching", process.Id);
+                return false;
+            }
+
+            using var handle = new SafeProcessHandle(rawHandle, ownsHandle: true);
+            var hProcess = handle.DangerousGetHandle();
+
+            // Get module base address via CreateRemoteThread + LoadLibraryW
+            // Works for both .exe and .dll — LoadLibraryW on an already-mapped exe returns its base address
+            // This works on suspended processes because the remote thread is not suspended
+            var moduleBase = LoadModuleRemotely(hProcess, module);
+
             if (moduleBase == 0)
             {
                 _logger.LogError("Module {Module} not found in process {Pid}", module, process.Id);
@@ -26,17 +42,8 @@ public class Patcher
 
             var targetAddress = moduleBase + offset;
 
-            var rawHandle = OpenProcess(PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_VM_WRITE, false, process.Id);
-            if (rawHandle == 0)
-            {
-                _logger.LogError("Failed to open process {Pid} for memory write", process.Id);
-                return false;
-            }
-
-            using var handle = new SafeProcessHandle(rawHandle, ownsHandle: true);
-
             // Change memory protection
-            if (!VirtualProtectEx(handle.DangerousGetHandle(), targetAddress, (uint)bytes.Length, PAGE_EXECUTE_READWRITE, out uint oldProtection))
+            if (!VirtualProtectEx(hProcess, targetAddress, (uint)bytes.Length, PAGE_EXECUTE_READWRITE, out uint oldProtection))
             {
                 _logger.LogError("Failed to change memory protection at {Address:X}", targetAddress);
                 return false;
@@ -45,7 +52,7 @@ public class Patcher
             try
             {
                 // Write the patch bytes
-                if (!WriteProcessMemory(handle.DangerousGetHandle(), targetAddress, bytes, (uint)bytes.Length, out _))
+                if (!WriteProcessMemory(hProcess, targetAddress, bytes, (uint)bytes.Length, out _))
                 {
                     _logger.LogError("Failed to write patch at {Address:X}", targetAddress);
                     return false;
@@ -56,8 +63,7 @@ public class Patcher
             }
             finally
             {
-                // Restore original protection
-                VirtualProtectEx(handle.DangerousGetHandle(), targetAddress, (uint)bytes.Length, oldProtection, out _);
+                VirtualProtectEx(hProcess, targetAddress, (uint)bytes.Length, oldProtection, out _);
             }
         }
         catch (Exception ex)
@@ -67,32 +73,73 @@ public class Patcher
         }
     }
 
-    private static nint GetModuleBaseAddress(Process process, string moduleName)
+    /// <summary>
+    /// Force-loads a DLL into the target process by calling LoadLibraryW via CreateRemoteThread.
+    /// Works on suspended processes because CreateRemoteThread creates a new, non-suspended thread.
+    /// Returns the module base address (LoadLibrary's return value) or 0 on failure.
+    /// </summary>
+    private nint LoadModuleRemotely(nint processHandle, string modulePath)
     {
-        // Module enumeration can fail on suspended processes (ERROR_PARTIAL_COPY)
-        // because the loader hasn't fully initialized. Retry a few times.
-        for (var attempt = 0; attempt < 10; attempt++)
+        var pathBytes = System.Text.Encoding.Unicode.GetBytes(modulePath + '\0');
+
+        // Allocate memory in target process for the DLL path string
+        var remoteMemory = VirtualAllocEx(processHandle, 0, (uint)pathBytes.Length, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        if (remoteMemory == 0)
         {
-            try
-            {
-                process.Refresh();
-
-                foreach (ProcessModule module in process.Modules)
-                {
-                    if (string.Equals(module.ModuleName, moduleName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return module.BaseAddress;
-                    }
-                }
-
-                return 0;
-            }
-            catch (System.ComponentModel.Win32Exception) when (attempt < 9)
-            {
-                Thread.Sleep(200);
-            }
+            _logger.LogError("Failed to allocate memory for module path in target process");
+            return 0;
         }
 
-        return 0;
+        try
+        {
+            // Write the DLL path into the allocated memory
+            if (!WriteProcessMemory(processHandle, remoteMemory, pathBytes, (uint)pathBytes.Length, out _))
+            {
+                _logger.LogError("Failed to write module path to target process");
+                return 0;
+            }
+
+            // Get LoadLibraryW address from our own kernel32 (same address in target due to ASLR shared base)
+            var kernel32 = GetModuleHandle("kernel32.dll");
+            var loadLibraryAddr = GetProcAddress(kernel32, "LoadLibraryW");
+            if (loadLibraryAddr == 0)
+            {
+                _logger.LogError("Failed to get LoadLibraryW address");
+                return 0;
+            }
+
+            // Create remote thread that calls LoadLibraryW(modulePath)
+            var rawThreadHandle = CreateRemoteThread(processHandle, 0, 0, loadLibraryAddr, remoteMemory, 0, out _);
+            if (rawThreadHandle == 0)
+            {
+                _logger.LogError("Failed to create remote thread for LoadLibraryW");
+                return 0;
+            }
+
+            using var threadHandle = new SafeProcessHandle(rawThreadHandle, ownsHandle: true);
+
+            // Wait for LoadLibraryW to complete
+            WaitForSingleObject(threadHandle.DangerousGetHandle(), INFINITE);
+
+            // LoadLibrary's return value is the module base address (or 0 on failure)
+            // Retrieved via the thread's exit code
+            if (!GetExitCodeThread(threadHandle.DangerousGetHandle(), out var moduleBase))
+            {
+                _logger.LogError("Failed to get exit code from LoadLibraryW thread");
+                return 0;
+            }
+
+            if (moduleBase == 0)
+            {
+                _logger.LogError("LoadLibraryW failed in target process for {ModulePath}", modulePath);
+                return 0;
+            }
+
+            return (nint)moduleBase;
+        }
+        finally
+        {
+            VirtualFreeEx(processHandle, remoteMemory, 0, MEM_RELEASE);
+        }
     }
 }

--- a/src/D2BotNG/Windows/ProcessManager.cs
+++ b/src/D2BotNG/Windows/ProcessManager.cs
@@ -148,6 +148,7 @@ public class ProcessManager
         SetWindowPos(hwnd, 0, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
     }
 
+
     public void ShowWindowAt(nint hwnd, int x, int y)
     {
         SetWindowPos(hwnd, 0, x, y, 0, 0, SWP_NOSIZE | SWP_SHOWWINDOW);


### PR DESCRIPTION
**Patcher**

- Fix patcher to allow multiple instance launches
- Fix slow startup with "Only part of a ReadProcessMemory or WriteProcessMemory
  request was completed" error — patching is now near-instant
- Skip window-hiding patches when the profile is configured as visible

**Bulk profile actions**

- Delete, ResetStats, TriggerMule, RotateKey, ReleaseKey now work on
  multiple selected profiles at once
- Replace single SetScheduleEnabled toggle with separate
  EnableSchedule/DisableSchedule actions

**Profile engine**

- Crash counter resets reliably on profile start
- Stale status clears between runs
- Unexpected process exits are always detected and treated as crashes

**Discord bot**

- Fix occasional gateway deadlock on startup

**Server startup**

- Show clear error message when port is already in use

**Window management**

- Minimize always goes to tray (taskbar right-click, Win+D, etc.)
- Fix maximize on multi-monitor setups

**Profiles UI**

- Right-click context menu on desktop (inline action buttons hidden on hover devices)
- Shift-click for range selection in profile table
- Multi-select bulk actions toolbar (start, stop, delete, rotate key, etc.)
- Column visibility selector moved to page toolbar
- Context menu: hide invalid actions instead of showing them disabled
- Mobile: tap to toggle profile selection (multi-select without Ctrl)

**Update notification**

- Dismissable with X button (reappears when update state changes)
- Cannot dismiss while downloading or installing

**Item cards**

- Ethereal indicator badge alongside socket count
- Fix card overflow on mobile (proper ellipsis on long item names)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>